### PR TITLE
Feature/googlecalendarapi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-backend/app/.env
+backend/.env
 backend/.venv
 backend/.vscode
 __pycache__/

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routes import user_route
-import os
-from fastapi_limiter import FastAPILimiter
-from app.db.session import engine
 from app.db.base import Base
+from app.db.session import engine
+from app.routes import calendar_route, user_route
 
 app = FastAPI()
 
@@ -15,9 +13,13 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
 @app.on_event("startup")
 async def startup():
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
-app.include_router(user_route.router,tags=["user"])
+
+app.include_router(user_route.router, tags=["user"])
+app.include_router(calendar_route.router, tags=["calendar"])

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,0 +1,3 @@
+"""Route modules for the FastAPI application."""
+
+__all__ = ["user_route", "calendar_route"]

--- a/backend/app/routes/calendar_route.py
+++ b/backend/app/routes/calendar_route.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import get_db
+from app.services.google_calendar_service import GoogleCalendarService
+from app.services.user_service import UserService
+from app.utils.jwt import verify_token
+
+security = HTTPBearer(auto_error=False)
+
+router = APIRouter(prefix="/calendar")
+
+
+@router.get("/events")
+async def list_events(
+    time_min: str | None = None,
+    time_max: str | None = None,
+    max_results: int = 50,
+    page_token: str | None = None,
+    db: AsyncSession = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+):
+    if credentials is None or not credentials.credentials:
+        raise HTTPException(status_code=401, detail="인증 토큰이 필요합니다.")
+
+    payload = verify_token(credentials.credentials)
+    user_id = payload.get("sub") if payload else None
+    if not user_id:
+        raise HTTPException(status_code=401, detail="유효하지 않은 토큰입니다.")
+
+    user = await UserService.get_user_by_google_id(user_id, db)
+    if not user or not getattr(user, "google_refresh_token", None):
+        return JSONResponse(
+            status_code=400,
+            content={
+                "code": "calendar_scope_missing",
+                "reauthUrl": "/user/google/login?force=1",
+            },
+        )
+
+    try:
+        access_token = GoogleCalendarService.refresh_access_token(
+            user.google_refresh_token
+        )
+    except HTTPException as exc:
+        if exc.status_code == 401:
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "code": "calendar_refresh_failed",
+                    "reauthUrl": "/user/google/login?force=1",
+                },
+            )
+        raise
+
+    events_payload = GoogleCalendarService.list_primary_events(
+        access_token,
+        time_min=time_min,
+        time_max=time_max,
+        max_results=max_results,
+        page_token=page_token,
+    )
+    return events_payload

--- a/backend/app/routes/user_route.py
+++ b/backend/app/routes/user_route.py
@@ -18,8 +18,8 @@ router = APIRouter(
 
 
 @router.get("/google/login")
-async def google_login():
-    auth_url = GoogleOAuthService.generate_auth_url()
+async def google_login(force: int | None = None):
+    auth_url = GoogleOAuthService.generate_auth_url(force_prompt_consent=bool(force))
     return {"auth_url": auth_url}
 
 

--- a/backend/app/routes/user_route.py
+++ b/backend/app/routes/user_route.py
@@ -1,12 +1,14 @@
-from fastapi import APIRouter, HTTPException, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import RedirectResponse
-from sqlalchemy.ext.asyncio import AsyncSession
 from fastapi.security import HTTPBearer
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from app.db.session import get_db
-from app.variable import FRONTEND_URL
 from app.services.google_oauth_service import GoogleOAuthService
 from app.services.user_service import UserService
 from app.utils.jwt import create_access_token
+from app.variable import FRONTEND_URL
+
 
 security = HTTPBearer()
 
@@ -14,10 +16,12 @@ router = APIRouter(
     prefix="/user",
 )
 
+
 @router.get("/google/login")
 async def google_login():
     auth_url = GoogleOAuthService.generate_auth_url()
     return {"auth_url": auth_url}
+
 
 @router.get("/callback")
 async def google_callback(code: str, db: AsyncSession = Depends(get_db)):
@@ -34,7 +38,9 @@ async def google_callback(code: str, db: AsyncSession = Depends(get_db)):
         name = user_info["name"]
 
         # 사용자 조회 또는 생성
-        user = await UserService.get_or_create_user(google_id, email, name, refresh_token, db)
+        user = await UserService.get_or_create_user(
+            google_id, email, name, refresh_token, db
+        )
 
         # JWT 토큰 생성
         jwt_access_token = create_access_token(data={"sub": user.user_id})

--- a/backend/app/services/google_calendar_service.py
+++ b/backend/app/services/google_calendar_service.py
@@ -100,9 +100,10 @@ class GoogleCalendarService:
             response.status_code,
             error_info,
         )
-
+        if response.status_code == 401:
+            raise HTTPException(status_code=401, detail="google_reauth_required")
         if response.status_code == 403:
-            raise HTTPException(status_code=403, detail="insufficient_permissions")
+            raise HTTPException(status_code=403, detail="insufficient_scope")
         if response.status_code == 429:
             raise HTTPException(status_code=429, detail="rate_limited")
 

--- a/backend/app/services/google_calendar_service.py
+++ b/backend/app/services/google_calendar_service.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import requests
+from fastapi import HTTPException
+
+from app.variable import GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GoogleCalendarService:
+    TOKEN_URL = "https://oauth2.googleapis.com/token"
+    EVENTS_URL = "https://www.googleapis.com/calendar/v3/calendars/primary/events"
+
+    @classmethod
+    def refresh_access_token(cls, refresh_token: str) -> str:
+        payload = {
+            "client_id": GOOGLE_CLIENT_ID,
+            "client_secret": GOOGLE_CLIENT_SECRET,
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+        }
+
+        try:
+            response = requests.post(cls.TOKEN_URL, data=payload, timeout=10)
+        except requests.RequestException as exc:  # pragma: no cover - network guard
+            LOGGER.exception("Failed to refresh Google access token: %s", exc)
+            raise HTTPException(
+                status_code=500, detail="구글 토큰 갱신 요청에 실패했습니다."
+            ) from exc
+
+        data: Dict[str, Any] = cls._safe_json(response)
+        if response.ok and data.get("access_token"):
+            return data["access_token"]
+
+        error = data.get("error")
+        description = data.get("error_description")
+        LOGGER.error(
+            "Google token refresh failed (status=%s, error=%s, description=%s)",
+            response.status_code,
+            error,
+            description,
+        )
+
+        if response.status_code == 400 and error == "invalid_grant":
+            raise HTTPException(status_code=401, detail="invalid_grant")
+
+        raise HTTPException(status_code=500, detail="구글 토큰 갱신에 실패했습니다.")
+
+    @classmethod
+    def list_primary_events(
+        cls,
+        access_token: str,
+        *,
+        time_min: Optional[str],
+        time_max: Optional[str],
+        max_results: int = 50,
+        page_token: Optional[str] = None,
+        time_zone: str = "Asia/Seoul",
+    ) -> Dict[str, Any]:
+        params: Dict[str, str] = {
+            "singleEvents": "true",
+            "orderBy": "startTime",
+            "timeZone": time_zone,
+            "maxResults": str(max_results),
+            "fields": "items(id,summary,location,start,end,htmlLink,updated),nextPageToken",
+        }
+        if time_min is not None:
+            params["timeMin"] = time_min
+        if time_max is not None:
+            params["timeMax"] = time_max
+        if page_token is not None:
+            params["pageToken"] = page_token
+
+        headers = {"Authorization": f"Bearer {access_token}"}
+
+        try:
+            response = requests.get(
+                cls.EVENTS_URL, headers=headers, params=params, timeout=10
+            )
+        except requests.RequestException as exc:  # pragma: no cover - network guard
+            LOGGER.exception("Failed to fetch Google Calendar events: %s", exc)
+            raise HTTPException(
+                status_code=500, detail="구글 캘린더 이벤트 조회에 실패했습니다."
+            ) from exc
+
+        data: Dict[str, Any] = cls._safe_json(response)
+        if response.ok:
+            return {
+                "events": data.get("items", []),
+                "nextPageToken": data.get("nextPageToken"),
+            }
+
+        error_info = cls._extract_calendar_error(data)
+        LOGGER.error(
+            "Google Calendar API error (status=%s, error=%s)",
+            response.status_code,
+            error_info,
+        )
+
+        if response.status_code == 403:
+            raise HTTPException(status_code=403, detail="insufficient_permissions")
+        if response.status_code == 429:
+            raise HTTPException(status_code=429, detail="rate_limited")
+
+        raise HTTPException(status_code=500, detail="구글 캘린더 조회에 실패했습니다.")
+
+    @staticmethod
+    def _safe_json(response: requests.Response) -> Dict[str, Any]:
+        try:
+            return response.json()
+        except ValueError:  # pragma: no cover - unexpected payload
+            return {}
+
+    @staticmethod
+    def _extract_calendar_error(data: Dict[str, Any]) -> Optional[str]:
+        error = data.get("error")
+        if isinstance(error, dict):
+            return error.get("message")
+        if isinstance(error, str):
+            return error
+        return None

--- a/backend/app/services/google_oauth_service.py
+++ b/backend/app/services/google_oauth_service.py
@@ -11,7 +11,7 @@ from app.variable import (
 
 class GoogleOAuthService:
     @staticmethod
-    def generate_auth_url():
+    def generate_auth_url(force_prompt_consent: bool = False):
         # Google OAuth 인증 URL 생성
         scope = (
             "openid email profile "
@@ -25,7 +25,7 @@ class GoogleOAuthService:
             "access_type": "offline",
             "include_granted_scopes": "true",
         }
-        if GOOGLE_FORCE_PROMPT_CONSENT:
+        if GOOGLE_FORCE_PROMPT_CONSENT or force_prompt_consent:
             params["prompt"] = "consent"
         return "https://accounts.google.com/o/oauth2/auth?" + urllib.parse.urlencode(
             params

--- a/backend/app/services/google_oauth_service.py
+++ b/backend/app/services/google_oauth_service.py
@@ -1,28 +1,39 @@
 import urllib.parse
 import requests
 from fastapi import HTTPException
-from app.variable import GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URI
+from app.variable import (
+    GOOGLE_CLIENT_ID,
+    GOOGLE_CLIENT_SECRET,
+    GOOGLE_FORCE_PROMPT_CONSENT,
+    GOOGLE_REDIRECT_URI,
+)
 
 
 class GoogleOAuthService:
-
     @staticmethod
     def generate_auth_url():
-        #Google OAuth 인증 URL 생성
-        scope = "openid email profile"
+        # Google OAuth 인증 URL 생성
+        scope = (
+            "openid email profile "
+            "https://www.googleapis.com/auth/calendar.events.readonly"
+        )
         params = {
             "client_id": GOOGLE_CLIENT_ID,
             "redirect_uri": GOOGLE_REDIRECT_URI,
             "scope": scope,
             "response_type": "code",
             "access_type": "offline",
-            "prompt": "consent"
+            "include_granted_scopes": "true",
         }
-        return "https://accounts.google.com/o/oauth2/auth?" + urllib.parse.urlencode(params)
+        if GOOGLE_FORCE_PROMPT_CONSENT:
+            params["prompt"] = "consent"
+        return "https://accounts.google.com/o/oauth2/auth?" + urllib.parse.urlencode(
+            params
+        )
 
     @staticmethod
     def exchange_code_for_tokens(code: str):
-        #인증 코드를 액세스 토큰과 리프레시 토큰으로 교환
+        # 인증 코드를 액세스 토큰과 리프레시 토큰으로 교환
         token_data = {
             "client_id": GOOGLE_CLIENT_ID,
             "client_secret": GOOGLE_CLIENT_SECRET,
@@ -33,8 +44,7 @@ class GoogleOAuthService:
 
         try:
             token_response = requests.post(
-                "https://oauth2.googleapis.com/token",
-                data=token_data
+                "https://oauth2.googleapis.com/token", data=token_data
             )
             token_response.raise_for_status()
             tokens = token_response.json()
@@ -45,16 +55,15 @@ class GoogleOAuthService:
             if not access_token:
                 raise HTTPException(status_code=400, detail="토큰을 받을 수 없습니다.")
 
-            return {
-                "access_token": access_token,
-                "refresh_token": refresh_token
-            }
+            return {"access_token": access_token, "refresh_token": refresh_token}
         except requests.RequestException as e:
-            raise HTTPException(status_code=500, detail=f"구글 토큰 요청 실패: {str(e)}")
+            raise HTTPException(
+                status_code=500, detail=f"구글 토큰 요청 실패: {str(e)}"
+            )
 
     @staticmethod
     def get_user_info(access_token: str):
-        #액세스 토큰으로 사용자 정보 조회
+        # 액세스 토큰으로 사용자 정보 조회
         try:
             user_info_response = requests.get(
                 f"https://www.googleapis.com/oauth2/v2/userinfo?access_token={access_token}"
@@ -67,12 +76,12 @@ class GoogleOAuthService:
             name = user_info.get("name")
 
             if not google_id or not email:
-                raise HTTPException(status_code=400, detail="사용자 정보를 가져올 수 없습니다.")
+                raise HTTPException(
+                    status_code=400, detail="사용자 정보를 가져올 수 없습니다."
+                )
 
-            return {
-                "google_id": google_id,
-                "email": email,
-                "name": name
-            }
+            return {"google_id": google_id, "email": email, "name": name}
         except requests.RequestException as e:
-            raise HTTPException(status_code=500, detail=f"구글 사용자 정보 요청 실패: {str(e)}")
+            raise HTTPException(
+                status_code=500, detail=f"구글 사용자 정보 요청 실패: {str(e)}"
+            )

--- a/backend/app/services/user_service.py
+++ b/backend/app/services/user_service.py
@@ -5,22 +5,23 @@ from app.models.user_model import User
 
 
 class UserService:
-
     @staticmethod
     async def get_user_by_google_id(google_id: str, db: AsyncSession):
-        #구글아이디로 유저조회
+        # 구글아이디로 유저조회
         result = await db.execute(select(User).where(User.user_id == google_id))
         return result.scalar_one_or_none()
 
     @staticmethod
-    async def create_user(google_id: str, email: str, name: str, refresh_token: str, db: AsyncSession):
-        #유저생성
+    async def create_user(
+        google_id: str, email: str, name: str, refresh_token: str, db: AsyncSession
+    ):
+        # 유저생성
         user = User(
             user_id=google_id,
             email=email,
             name=name,
             google_refresh_token=refresh_token or "",
-            created_at=date.today()
+            created_at=date.today(),
         )
         db.add(user)
         await db.commit()
@@ -28,19 +29,26 @@ class UserService:
         return user
 
     @staticmethod
-    async def update_refresh_token(user: User, refresh_token: str, db: AsyncSession):
-        #리프레시토큰 업데이트
-        if refresh_token:
-            user.google_refresh_token = refresh_token
-            await db.commit()
+    async def update_refresh_token(
+        user: User, refresh_token: str | None, db: AsyncSession
+    ):  # 리프레시토큰 업데이트
+        if refresh_token is None or refresh_token == "":
+            return
+
+        user.google_refresh_token = refresh_token
+        await db.commit()
 
     @staticmethod
-    async def get_or_create_user(google_id: str, email: str, name: str, refresh_token: str, db: AsyncSession):
-        #유저 가입여부 확인 및 업데이트
+    async def get_or_create_user(
+        google_id: str, email: str, name: str, refresh_token: str, db: AsyncSession
+    ):
+        # 유저 가입여부 확인 및 업데이트
         user = await UserService.get_user_by_google_id(google_id, db)
 
         if not user:
-            user = await UserService.create_user(google_id, email, name, refresh_token, db)
+            user = await UserService.create_user(
+                google_id, email, name, refresh_token, db
+            )
         else:
             await UserService.update_refresh_token(user, refresh_token, db)
 

--- a/backend/app/variable.py
+++ b/backend/app/variable.py
@@ -2,18 +2,23 @@ import os
 from dotenv import load_dotenv
 
 
-
 load_dotenv()
 
 
 SQLALCHEMY_DATABASE_URL_USER = os.environ.get("SQLALCHEMY_DATABASE_URL_USER")
 SECRET_KEY = os.environ.get("SECRET_KEY")
 ALGORITHM = os.environ.get("ALGORITHM")
-ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES"))
-REFRESH_TOKEN_EXPIRE_MINUTES = int(os.environ.get("REFRESH_TOKEN_EXPIRE_MINUTES"))
+ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES", "60"))
+REFRESH_TOKEN_EXPIRE_MINUTES = int(
+    os.environ.get("REFRESH_TOKEN_EXPIRE_MINUTES", "86400")
+)
+
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
 GOOGLE_REDIRECT_URI = os.getenv("GOOGLE_REDIRECT_URI")
-FRONTEND_URL = os.getenv("FRONTEND_URL","localhost:5173")
+GOOGLE_FORCE_PROMPT_CONSENT = (
+    os.getenv("GOOGLE_FORCE_PROMPT_CONSENT", "false").lower() == "true"
+)
 
+FRONTEND_URL = os.getenv("FRONTEND_URL", "localhost:5173")

--- a/backend/tests/integration/test_oauth_flow.py
+++ b/backend/tests/integration/test_oauth_flow.py
@@ -1,0 +1,168 @@
+import importlib
+import sys
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture
+def oauth_modules(monkeypatch):
+    """OAuth 관련 모듈을 테스트 환경으로 재로딩한다."""
+
+    root_dir = Path(__file__).resolve().parents[2]
+    if str(root_dir) not in sys.path:
+        sys.path.insert(0, str(root_dir))
+
+    monkeypatch.setenv("SECRET_KEY", "test-secret")
+    monkeypatch.setenv("ALGORITHM", "HS256")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+    monkeypatch.setenv("REFRESH_TOKEN_EXPIRE_MINUTES", "120")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URL_USER", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "client")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
+    monkeypatch.setenv("GOOGLE_REDIRECT_URI", "http://localhost/callback")
+    monkeypatch.setenv("GOOGLE_FORCE_PROMPT_CONSENT", "false")
+    monkeypatch.setenv("FRONTEND_URL", "http://frontend")
+    monkeypatch.setenv("ANYIO_BACKEND", "asyncio")
+
+    import app.variable
+
+    monkeypatch.setattr(
+        "sqlalchemy.ext.asyncio.create_async_engine", lambda *a, **k: SimpleNamespace()
+    )
+
+    importlib.reload(app.variable)
+
+    import app.services.google_oauth_service as google_service
+    import app.services.user_service as user_service
+    import app.utils.jwt as jwt_utils
+    import app.routes.user_route as user_route
+
+    google_service = importlib.reload(google_service)
+    user_service = importlib.reload(user_service)
+    jwt_utils = importlib.reload(jwt_utils)
+    user_route = importlib.reload(user_route)
+
+    return SimpleNamespace(
+        google_service=google_service,
+        user_service=user_service,
+        jwt_utils=jwt_utils,
+        user_route=user_route,
+    )
+
+
+def test_google_login_returns_composed_url(oauth_modules):
+    response = asyncio.run(oauth_modules.user_route.google_login())
+
+    auth_url = response["auth_url"]
+    query = parse_qs(urlparse(auth_url).query)
+
+    assert query["client_id"] == ["client"]
+    assert query["redirect_uri"] == ["http://localhost/callback"]
+    assert query["scope"] == [
+        "openid email profile https://www.googleapis.com/auth/calendar.events.readonly"
+    ]
+    assert query["access_type"] == ["offline"]
+    assert query["include_granted_scopes"] == ["true"]
+
+
+def test_google_callback_success_returns_redirect(oauth_modules, monkeypatch):
+    google_service = oauth_modules.google_service
+    user_service = oauth_modules.user_service
+    monkeypatch.setattr(
+        google_service.GoogleOAuthService,
+        "exchange_code_for_tokens",
+        staticmethod(
+            lambda code: {"access_token": "access", "refresh_token": "refresh"}
+        ),
+    )
+    monkeypatch.setattr(
+        google_service.GoogleOAuthService,
+        "get_user_info",
+        staticmethod(
+            lambda token: {
+                "google_id": "gid",
+                "email": "user@example.com",
+                "name": "User",
+            }
+        ),
+    )
+    monkeypatch.setattr(
+        user_service.UserService,
+        "get_or_create_user",
+        AsyncMock(return_value=SimpleNamespace(user_id="gid")),
+    )
+    monkeypatch.setattr(
+        oauth_modules.user_route, "create_access_token", lambda data: "jwt-token"
+    )
+
+    redirect = asyncio.run(
+        oauth_modules.user_route.google_callback("auth-code", db=SimpleNamespace())
+    )
+
+    assert redirect.status_code == 307
+    assert (
+        redirect.headers["location"]
+        == "http://frontend/auth/callback?access_token=jwt-token"
+    )
+
+
+def test_google_callback_propagates_http_exception(oauth_modules, monkeypatch):
+    google_service = oauth_modules.google_service
+
+    def _raise_http_exc(code: str):
+        raise HTTPException(status_code=400, detail="invalid code")
+
+    monkeypatch.setattr(
+        google_service.GoogleOAuthService,
+        "exchange_code_for_tokens",
+        staticmethod(_raise_http_exc),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            oauth_modules.user_route.google_callback("bad", db=SimpleNamespace())
+        )
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "invalid code"
+
+
+def test_google_callback_wraps_unexpected_error(oauth_modules, monkeypatch):
+    google_service = oauth_modules.google_service
+    user_service = oauth_modules.user_service
+
+    monkeypatch.setattr(
+        google_service.GoogleOAuthService,
+        "exchange_code_for_tokens",
+        staticmethod(lambda code: {"access_token": "a", "refresh_token": "r"}),
+    )
+    monkeypatch.setattr(
+        google_service.GoogleOAuthService,
+        "get_user_info",
+        staticmethod(
+            lambda token: {
+                "google_id": "gid",
+                "email": "user@example.com",
+                "name": "User",
+            }
+        ),
+    )
+
+    async def _raise(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(user_service.UserService, "get_or_create_user", _raise)
+
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(
+            oauth_modules.user_route.google_callback("code", db=SimpleNamespace())
+        )
+
+    assert exc.value.status_code == 500
+    assert exc.value.detail == "로그인 처리 중 오류: db down"

--- a/backend/tests/routes/test_calendar_route.py
+++ b/backend/tests/routes/test_calendar_route.py
@@ -1,0 +1,125 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    root_dir = Path(__file__).resolve().parents[2]
+    if str(root_dir) not in sys.path:
+        sys.path.insert(0, str(root_dir))
+
+    monkeypatch.setenv("SECRET_KEY", "secret")
+    monkeypatch.setenv("ALGORITHM", "HS256")
+    monkeypatch.setenv("ACCESS_TOKEN_EXPIRE_MINUTES", "60")
+    monkeypatch.setenv("SQLALCHEMY_DATABASE_URL_USER", "sqlite+aiosqlite:///:memory:")
+
+    import app.variable
+
+    importlib.reload(app.variable)
+
+
+@pytest.fixture
+def route_module(monkeypatch):
+    import app.routes.calendar_route as calendar_route
+
+    calendar_route = importlib.reload(calendar_route)
+
+    return calendar_route
+
+
+def test_requires_jwt_header(route_module):
+    with pytest.raises(HTTPException) as exc:
+        asyncio.run(route_module.list_events(credentials=None))
+
+    assert exc.value.status_code == 401
+
+
+def test_missing_refresh_token_returns_scope_error(route_module, monkeypatch):
+    monkeypatch.setattr(route_module, "verify_token", lambda token: {"sub": "user"})
+
+    async def _get_user(*args, **kwargs):
+        return SimpleNamespace(google_refresh_token="")
+
+    monkeypatch.setattr(route_module.UserService, "get_user_by_google_id", _get_user)
+
+    response = asyncio.run(
+        route_module.list_events(
+            db=SimpleNamespace(),
+            credentials=SimpleNamespace(scheme="Bearer", credentials="jwt"),
+        )
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 400
+    assert (
+        response.body
+        == b'{"code":"calendar_scope_missing","reauthUrl":"/user/google/login?force=1"}'
+    )
+
+
+def test_successful_event_fetch(route_module, monkeypatch):
+    monkeypatch.setattr(route_module, "verify_token", lambda token: {"sub": "user"})
+
+    async def _get_user(*args, **kwargs):
+        return SimpleNamespace(google_refresh_token="refresh")
+
+    monkeypatch.setattr(route_module.UserService, "get_user_by_google_id", _get_user)
+    monkeypatch.setattr(
+        route_module.GoogleCalendarService,
+        "refresh_access_token",
+        lambda refresh: "access",
+    )
+    monkeypatch.setattr(
+        route_module.GoogleCalendarService,
+        "list_primary_events",
+        lambda *a, **k: {"events": [1, 2], "nextPageToken": "next"},
+    )
+
+    result = asyncio.run(
+        route_module.list_events(
+            db=SimpleNamespace(),
+            credentials=SimpleNamespace(scheme="Bearer", credentials="jwt"),
+            max_results=10,
+        )
+    )
+
+    assert result == {"events": [1, 2], "nextPageToken": "next"}
+
+
+def test_invalid_grant_triggers_reauth(route_module, monkeypatch):
+    monkeypatch.setattr(route_module, "verify_token", lambda token: {"sub": "user"})
+
+    async def _get_user(*args, **kwargs):
+        return SimpleNamespace(google_refresh_token="refresh")
+
+    monkeypatch.setattr(route_module.UserService, "get_user_by_google_id", _get_user)
+
+    def _raise_invalid_grant(refresh):
+        raise HTTPException(status_code=401, detail="invalid_grant")
+
+    monkeypatch.setattr(
+        route_module.GoogleCalendarService,
+        "refresh_access_token",
+        _raise_invalid_grant,
+    )
+
+    response = asyncio.run(
+        route_module.list_events(
+            db=SimpleNamespace(),
+            credentials=SimpleNamespace(scheme="Bearer", credentials="jwt"),
+        )
+    )
+
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 401
+    assert (
+        response.body
+        == b'{"code":"calendar_refresh_failed","reauthUrl":"/user/google/login?force=1"}'
+    )

--- a/backend/tests/services/test_google_calendar_service.py
+++ b/backend/tests/services/test_google_calendar_service.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 from fastapi import HTTPException
@@ -21,23 +22,21 @@ def setup_env(monkeypatch):
 
 
 @pytest.fixture
-def service_module(monkeypatch):
+def service_module():
     import app.services.google_calendar_service as module
 
-    module = importlib.reload(module)
-
-    yield module
+    return importlib.reload(module)
 
 
 class _FakeResponse:
-    def __init__(self, status_code=200, data=None):
+    def __init__(self, status_code: int = 200, data: Dict[str, Any] | None = None):
         self.status_code = status_code
         self._data = data or {}
         self.ok = 200 <= status_code < 300
 
-    def json(self):
+    def json(self) -> Dict[str, Any]:
         if self._data is None:
-            raise ValueError("no json")
+            raise ValueError("no json payload")
         return self._data
 
 
@@ -50,61 +49,91 @@ def test_refresh_access_token_success(service_module, monkeypatch):
     assert token == "new-token"
 
 
-@pytest.mark.parametrize(
-    "status_code,data,expected_status",
-    [
-        (400, {"error": "invalid_grant"}, 401),
-        (500, {"error": "server_error"}, 500),
-    ],
-)
-def test_refresh_access_token_failure(
-    service_module, monkeypatch, status_code, data, expected_status
-):
-    response = _FakeResponse(status_code=status_code, data=data)
+def test_refresh_access_token_invalid_grant(service_module, monkeypatch):
+    response = _FakeResponse(status_code=400, data={"error": "invalid_grant"})
     monkeypatch.setattr(service_module.requests, "post", lambda *a, **k: response)
 
     with pytest.raises(HTTPException) as exc:
         service_module.GoogleCalendarService.refresh_access_token("refresh")
 
-    assert exc.value.status_code == expected_status
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "invalid_grant"
+
+
+def test_refresh_access_token_server_error(service_module, monkeypatch):
+    response = _FakeResponse(status_code=503, data={"error": "server_error"})
+    monkeypatch.setattr(service_module.requests, "post", lambda *a, **k: response)
+
+    with pytest.raises(HTTPException) as exc:
+        service_module.GoogleCalendarService.refresh_access_token("refresh")
+
+    assert exc.value.status_code == 500
 
 
 def test_list_primary_events_success(service_module, monkeypatch):
-    payload = {"items": [{"id": "1"}], "nextPageToken": "token"}
-    response = _FakeResponse(data=payload)
-    monkeypatch.setattr(service_module.requests, "get", lambda *a, **k: response)
+    captured: Dict[str, Any] = {}
+
+    def _fake_get(*args, **kwargs):
+        captured.update(kwargs)
+        return _FakeResponse(
+            data={"items": [{"id": "1"}], "nextPageToken": "next-token"}
+        )
+
+    monkeypatch.setattr(service_module.requests, "get", _fake_get)
 
     result = service_module.GoogleCalendarService.list_primary_events(
         "access",
         time_min="2024-01-01T00:00:00Z",
         time_max="2024-01-31T23:59:59Z",
         max_results=10,
-        page_token="next",
+        page_token="page",
     )
 
-    assert result == {"events": payload["items"], "nextPageToken": "token"}
+    assert result == {"events": [{"id": "1"}], "nextPageToken": "next-token"}
+    assert captured["headers"] == {"Authorization": "Bearer access"}
+    assert captured["params"]["timeMin"] == "2024-01-01T00:00:00Z"
+    assert captured["params"]["timeMax"] == "2024-01-31T23:59:59Z"
+    assert captured["params"]["pageToken"] == "page"
+    assert captured["params"]["maxResults"] == "10"
 
 
-@pytest.mark.parametrize(
-    "status_code,expected_status",
-    [
-        (403, 403),
-        (429, 429),
-        (500, 500),
-    ],
-)
-def test_list_primary_events_errors(
-    service_module, monkeypatch, status_code, expected_status
-):
-    data = {"error": {"message": "nope"}}
-    response = _FakeResponse(status_code=status_code, data=data)
+def test_list_primary_events_forbidden(service_module, monkeypatch):
+    response = _FakeResponse(
+        status_code=403, data={"error": {"message": "insufficient"}}
+    )
+
     monkeypatch.setattr(service_module.requests, "get", lambda *a, **k: response)
 
     with pytest.raises(HTTPException) as exc:
         service_module.GoogleCalendarService.list_primary_events(
-            "access",
-            time_min=None,
-            time_max=None,
+            "access", time_min=None, time_max=None
         )
 
-    assert exc.value.status_code == expected_status
+    assert exc.value.status_code == 403
+    assert exc.value.detail == "insufficient_scope"
+
+
+def test_list_primary_events_requires_reauth(service_module, monkeypatch):
+    response = _FakeResponse(status_code=401, data={"error": "invalid"})
+    monkeypatch.setattr(service_module.requests, "get", lambda *a, **k: response)
+
+    with pytest.raises(HTTPException) as exc:
+        service_module.GoogleCalendarService.list_primary_events(
+            "access", time_min=None, time_max=None
+        )
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail == "google_reauth_required"
+
+
+def test_list_primary_events_rate_limited(service_module, monkeypatch):
+    response = _FakeResponse(status_code=429, data={"error": {"message": "slow"}})
+    monkeypatch.setattr(service_module.requests, "get", lambda *a, **k: response)
+
+    with pytest.raises(HTTPException) as exc:
+        service_module.GoogleCalendarService.list_primary_events(
+            "access", time_min=None, time_max=None
+        )
+
+    assert exc.value.status_code == 429
+    assert exc.value.detail == "rate_limited"

--- a/backend/tests/services/test_google_calendar_service.py
+++ b/backend/tests/services/test_google_calendar_service.py
@@ -1,0 +1,110 @@
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture(autouse=True)
+def setup_env(monkeypatch):
+    root_dir = Path(__file__).resolve().parents[2]
+    if str(root_dir) not in sys.path:
+        sys.path.insert(0, str(root_dir))
+
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "client")
+    monkeypatch.setenv("GOOGLE_CLIENT_SECRET", "secret")
+
+    import app.variable
+
+    importlib.reload(app.variable)
+
+
+@pytest.fixture
+def service_module(monkeypatch):
+    import app.services.google_calendar_service as module
+
+    module = importlib.reload(module)
+
+    yield module
+
+
+class _FakeResponse:
+    def __init__(self, status_code=200, data=None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.ok = 200 <= status_code < 300
+
+    def json(self):
+        if self._data is None:
+            raise ValueError("no json")
+        return self._data
+
+
+def test_refresh_access_token_success(service_module, monkeypatch):
+    response = _FakeResponse(data={"access_token": "new-token"})
+    monkeypatch.setattr(service_module.requests, "post", lambda *a, **k: response)
+
+    token = service_module.GoogleCalendarService.refresh_access_token("refresh")
+
+    assert token == "new-token"
+
+
+@pytest.mark.parametrize(
+    "status_code,data,expected_status",
+    [
+        (400, {"error": "invalid_grant"}, 401),
+        (500, {"error": "server_error"}, 500),
+    ],
+)
+def test_refresh_access_token_failure(
+    service_module, monkeypatch, status_code, data, expected_status
+):
+    response = _FakeResponse(status_code=status_code, data=data)
+    monkeypatch.setattr(service_module.requests, "post", lambda *a, **k: response)
+
+    with pytest.raises(HTTPException) as exc:
+        service_module.GoogleCalendarService.refresh_access_token("refresh")
+
+    assert exc.value.status_code == expected_status
+
+
+def test_list_primary_events_success(service_module, monkeypatch):
+    payload = {"items": [{"id": "1"}], "nextPageToken": "token"}
+    response = _FakeResponse(data=payload)
+    monkeypatch.setattr(service_module.requests, "get", lambda *a, **k: response)
+
+    result = service_module.GoogleCalendarService.list_primary_events(
+        "access",
+        time_min="2024-01-01T00:00:00Z",
+        time_max="2024-01-31T23:59:59Z",
+        max_results=10,
+        page_token="next",
+    )
+
+    assert result == {"events": payload["items"], "nextPageToken": "token"}
+
+
+@pytest.mark.parametrize(
+    "status_code,expected_status",
+    [
+        (403, 403),
+        (429, 429),
+        (500, 500),
+    ],
+)
+def test_list_primary_events_errors(
+    service_module, monkeypatch, status_code, expected_status
+):
+    data = {"error": {"message": "nope"}}
+    response = _FakeResponse(status_code=status_code, data=data)
+    monkeypatch.setattr(service_module.requests, "get", lambda *a, **k: response)
+
+    with pytest.raises(HTTPException) as exc:
+        service_module.GoogleCalendarService.list_primary_events(
+            "access",
+            time_min=None,
+            time_max=None,
+        )
+
+    assert exc.value.status_code == expected_status

--- a/backend/tests/services/test_user_service.py
+++ b/backend/tests/services/test_user_service.py
@@ -103,6 +103,40 @@ def test_update_refresh_token(session_factory):
     assert updated_token == "new-refresh"
 
 
+def test_update_refresh_token_ignores_none(session_factory):
+    from app.services.user_service import UserService
+
+    async def scenario():
+        async with session_factory() as session:
+            user = await UserService.create_user(
+                "gid", "user@example.com", "User", "refresh", session
+            )
+            await UserService.update_refresh_token(user, None, session)
+            await session.refresh(user)
+            return user.google_refresh_token
+
+    token = asyncio.run(scenario())
+
+    assert token == "refresh"
+
+
+def test_update_refresh_token_ignores_empty_string(session_factory):
+    from app.services.user_service import UserService
+
+    async def scenario():
+        async with session_factory() as session:
+            user = await UserService.create_user(
+                "gid", "user@example.com", "User", "refresh", session
+            )
+            await UserService.update_refresh_token(user, "", session)
+            await session.refresh(user)
+            return user.google_refresh_token
+
+    token = asyncio.run(scenario())
+
+    assert token == "refresh"
+
+
 def test_get_or_create_user_creates_new(session_factory):
     from app.services.user_service import UserService
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         context: ./backend
       volumes:
         - ./backend:/app
-      # env_file:
-      #   - ./backend/.env
+      env_file:
+         - ./backend/.env
       ports:
         - "7777:7777"


### PR DESCRIPTION
## 📝작업 내용

> Summary
- /calendar/events 엔드포인트를 추가해 JWT를 검증하고, 구글 리프레시 토큰이 없거나 만료된 경우 재인증 URL을 반환하도록 처리했습니다.
- GoogleCalendarService를 도입해 리프레시 토큰으로 액세스 토큰을 갱신하고, 기본 캘린더 이벤트를 조회하며 401/403/429 등 주요 오류 코드를 세분화해 FastAPI 예외로 전달합니다.
- 라우트와 서비스 계층에 대한 단위 테스트를 추가해 토큰 검증, 재인증 분기, 권한 부족, 속도 제한 응답 등 핵심 시나리오를 검증했습니다.

> 상세 내용
- HTTPBearer 보안 스킴을 사용해 토큰 누락 시 즉시 401 예외를 발생시키고, 토큰 파싱 실패도 인증 오류로 간주하도록 했습니다.
- 사용자 조회 시 리프레시 토큰이 없으면 calendar_scope_missing 코드를 내려 프런트엔드가 재동의 플로우를 안내할 수 있도록 했습니다.
- 토큰 갱신 또는 이벤트 조회가 401/403을 반환하는 경우 각각 google_reauth_required, insufficient_scope 코드와 재인증 URL을 JSON 응답으로 내려 사용자의 재인증을 유도합니다.
- GoogleCalendarService는 토큰 갱신 시 invalid_grant를 401로 변환하고, 이벤트 조회 시 요청 파라미터(기간, 페이지네이션, 타임존)를 구성한 뒤 응답 본문에서 필요한 필드를 추려 반환합니다.
- _safe_json과 _extract_calendar_error 유틸리티로 구글 API의 비정상 JSON이나 오류 메시지를 안전하게 파싱해 로깅과 예외 메시지를 명확히 했습니다.
- 테스트에서는 몽키패치된 요청 객체로 외부 네트워크 의존성을 제거하고, 각 시나리오별로 FastAPI 예외 및 JSON 응답 본문을 검증하여 회귀를 방지합니다.

